### PR TITLE
Create new quote

### DIFF
--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -50,7 +50,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/AddQuoteCommand"
+              $ref: "#/components/schemas/CreateQuoteCommand"
         required: true
       responses:
         "200":
@@ -58,7 +58,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/AddQuoteResponse"
+                $ref: "#/components/schemas/CreateQuoteResponse"
     get:
       tags:
         - Quotes
@@ -231,13 +231,11 @@ components:
           type: string
         address:
           type: string
-          nullable: true
         phone:
           type: string
           nullable: true
         email:
           type: string
-          nullable: true
       required:
         - name
         - address
@@ -319,7 +317,7 @@ components:
         - description
         - quantity
         - unitPrice
-    AddQuoteResponse:
+    CreateQuoteResponse:
       type: object
       additionalProperties: false
       properties:
@@ -327,7 +325,7 @@ components:
           type: string
       required:
         - id
-    AddQuoteCommand:
+    CreateQuoteCommand:
       type: object
       additionalProperties: false
       properties:
@@ -340,20 +338,6 @@ components:
           nullable: true
         customerEmail:
           type: string
-        mobilePhoneMake:
-          type: string
-          nullable: true
-        mobilePhoneModel:
-          type: string
-          nullable: true
-        price:
-          type: number
-          format: decimal
-          nullable: true
-        discount:
-          type: number
-          format: decimal
-          nullable: true
       required:
         - customerName
         - customerAddress

--- a/ui/mockApi/mockData/index.js
+++ b/ui/mockApi/mockData/index.js
@@ -1,4 +1,5 @@
 const quotes = require('./quotes');
+const quoteDetails = require('./quoteDetails');
 
 module.exports = {
   quotes,

--- a/ui/mockApi/mockData/index.js
+++ b/ui/mockApi/mockData/index.js
@@ -1,5 +1,4 @@
 const quotes = require('./quotes');
-const quoteDetails = require('./quoteDetails');
 
 module.exports = {
   quotes,

--- a/ui/mockApi/mockData/quotes.js
+++ b/ui/mockApi/mockData/quotes.js
@@ -6,6 +6,9 @@ module.exports = [
     lastModifiedAt: '2-Mar-2020',
     customer: {
       name: 'Rahul',
+      email: 'a.b@c.com',
+      phone: '012345678',
+      address: '100 Ann Street, Brisbane City, 4000',
     },
     mobilePhone: {},
     accessories: [],

--- a/ui/mockApi/server.js
+++ b/ui/mockApi/server.js
@@ -30,8 +30,8 @@ router.render = (req, res) => {
       data = data.map(renderHelpers.toQuoteSummary);
     }
     if (scenariosHeader && Array.isArray(data) && data.length > 0) {
-      const filteredByScenario = data.filter(d =>
-        scenarios.every(scenario => d.scenarios && d.scenarios.includes(scenario))
+      const filteredByScenario = data.filter((d) =>
+        scenarios.every((scenario) => d.scenarios && d.scenarios.includes(scenario))
       );
       res.jsonp(filteredByScenario);
     } else res.jsonp(data);

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -13447,6 +13447,11 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.7.tgz",
       "integrity": "sha512-TAv1KJFh3RhqxNvhzxj6LeT5NWklP6rDr2a0jaTfsZ5wSZWHOGeqQyejUp3xxLfPt2UpyJEcVQB/zyPcmonNFA=="
     },
+    "react-hook-form": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-5.2.0.tgz",
+      "integrity": "sha512-EqGCSl3DxSUBtL/9lFvrFQLJ7ICdVKrfjcMHay2SvmU4trR8aqrd7YuiLSojBKmZBRdBnCcxG+LzLWF9z474NA=="
+    },
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",

--- a/ui/package.json
+++ b/ui/package.json
@@ -19,6 +19,7 @@
     "nan": "^2.14.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
+    "react-hook-form": "^5.2.0",
     "react-router-dom": "^5.1.2",
     "react-scripts": "3.4.1",
     "react-toastify": "^5.5.0",

--- a/ui/src/api/api-models.ts
+++ b/ui/src/api/api-models.ts
@@ -9,9 +9,9 @@
 
 export interface CustomerDto {
   name: string;
-  address: string | undefined;
+  address: string;
   phone?: string | undefined;
-  email: string | undefined;
+  email: string;
 }
 
 export interface QuoteDto {
@@ -46,19 +46,15 @@ export interface QuoteAccessoryDto {
   unitPrice: number;
 }
 
-export interface AddQuoteResponse {
+export interface CreateQuoteResponse {
   id: string;
 }
 
-export interface AddQuoteCommand {
+export interface CreateQuoteCommand {
   customerName: string;
   customerAddress: string;
   customerPhone?: string | undefined;
   customerEmail: string;
-  mobilePhoneMake?: string | undefined;
-  mobilePhoneModel?: string | undefined;
-  price?: number | undefined;
-  discount?: number | undefined;
 }
 
 export interface UpdateQuoteCustomerCommand {

--- a/ui/src/api/quotes.api.ts
+++ b/ui/src/api/quotes.api.ts
@@ -1,4 +1,10 @@
-import { QuoteDto, QuoteSummaryDto } from './api-models';
+import {
+  CreateQuoteCommand,
+  CreateQuoteResponse,
+  QuoteDto,
+  QuoteSummaryDto,
+  UpdateQuoteCustomerCommand,
+} from './api-models';
 import http from './http';
 
 export async function loadAllQuotes(): Promise<QuoteSummaryDto[]> {
@@ -9,4 +15,13 @@ export async function loadAllQuotes(): Promise<QuoteSummaryDto[]> {
 export async function loadQuote(id: string): Promise<QuoteDto> {
   const response = await http.get<QuoteDto>(`/api/quotes/${id}`);
   return response.data;
+}
+
+export async function createQuote(command: CreateQuoteCommand): Promise<CreateQuoteResponse> {
+  const response = await http.post<CreateQuoteResponse>('/api/quotes', command);
+  return response.data;
+}
+
+export async function updateQuoteCustomer(command: UpdateQuoteCustomerCommand): Promise<void> {
+  await http.put(`/api/quotes/${command.quoteId}/customer`, command);
 }

--- a/ui/src/api/quotes.api.ts
+++ b/ui/src/api/quotes.api.ts
@@ -7,6 +7,6 @@ export async function loadAllQuotes(): Promise<QuoteSummaryDto[]> {
 }
 
 export async function loadQuote(id: string): Promise<QuoteDto> {
-  const response = await http.get<QuoteDto>(`/api/quote/${id}`);
+  const response = await http.get<QuoteDto>(`/api/quotes/${id}`);
   return response.data;
 }

--- a/ui/src/api/quotes.api.ts
+++ b/ui/src/api/quotes.api.ts
@@ -1,7 +1,12 @@
-import { QuoteSummaryDto } from './api-models';
+import { QuoteDto, QuoteSummaryDto } from './api-models';
 import http from './http';
 
 export async function loadAllQuotes(): Promise<QuoteSummaryDto[]> {
   const response = await http.get<QuoteSummaryDto[]>('/api/quotes');
+  return response.data;
+}
+
+export async function loadQuote(id: string): Promise<QuoteDto> {
+  const response = await http.get<QuoteDto>(`/api/quote/${id}`);
   return response.data;
 }

--- a/ui/src/views/routes/Routes.tsx
+++ b/ui/src/views/routes/Routes.tsx
@@ -3,6 +3,7 @@ import { Redirect, Route, Switch, useLocation } from 'react-router-dom';
 import { ErrorBoundary } from 'views/components/application/ErrorBoundary';
 import { Shell } from 'views/components/application/Shell';
 import { NotFound } from './NotFound';
+import { Quote } from './quotes/Quote';
 import { QuotesList } from './quotes/QuotesList';
 
 export const Routes: React.FC = function() {
@@ -15,6 +16,12 @@ export const Routes: React.FC = function() {
           <Redirect exact from="/" to="/quotes" />
           <Route exact path="/quotes">
             <QuotesList />
+          </Route>
+          <Route exact path="/quotes/new">
+            <Quote />
+          </Route>
+          <Route exact path="/quotes/:quoteId">
+            <Quote />
           </Route>
           <Route>
             <NotFound />

--- a/ui/src/views/routes/quotes/CustomerSection.module.scss
+++ b/ui/src/views/routes/quotes/CustomerSection.module.scss
@@ -1,0 +1,25 @@
+.fields {
+  display: grid;
+  max-width: 40em;
+  grid-template-columns: 2fr 1fr;
+  grid-template-areas:
+    'name phone'
+    'address email';
+  column-gap: 16px;
+
+  .name {
+    grid-area: name;
+  }
+
+  .phone {
+    grid-area: phone;
+  }
+
+  .address {
+    grid-area: address;
+  }
+
+  .email {
+    grid-area: email;
+  }
+}

--- a/ui/src/views/routes/quotes/CustomerSection.tsx
+++ b/ui/src/views/routes/quotes/CustomerSection.tsx
@@ -10,20 +10,9 @@ import { QuoteSection } from './QuoteSection';
 
 export const CustomerSection: React.FC = () => {
   const history = useHistory();
-  const quote = useContext(QuoteContext);
+  const { quote } = useContext(QuoteContext);
   const formMethods = useForm<CustomerDto>();
-  const { register, errors, setValue } = formMethods;
-
-  React.useEffect(() => {
-    // dont know why setting defaultValue on TextField didn't work
-    // e.g defaultValue={quote?.customer.name}
-    // refer to https://react-hook-form.com/get-started#Integrateglobalstate
-    // set the value explicitly here as a second option
-    setValue('name', quote?.customer.name);
-    setValue('phone', quote?.customer.phone);
-    setValue('email', quote?.customer.email);
-    setValue('address', quote?.customer.address);
-  }, [quote, setValue]);
+  const { register, errors } = formMethods;
 
   const onSubmit = async (data: CustomerDto) => {
     if (quote) {
@@ -47,18 +36,26 @@ export const CustomerSection: React.FC = () => {
     }
   };
 
+  /*
+    Caveat: https://github.com/mui-org/material-ui/issues/11150
+    defaultValue in TextField won't update when the component reloads
+    use a LoadingPane to prevent the component from rendering until the data is fetched
+ */
   return (
     <QuoteSection<CustomerDto>
       sectionTitle={quote ? quote.customer.name : ''}
       sectionSummary=""
+      expandedDefault={!quote}
+      editableDefault={!quote}
       formMethods={formMethods}
       onSubmit={onSubmit}>
-      {editable => (
+      {(editable) => (
         <div className={styles.fields}>
           <TextField
             className={styles.name}
             name="name"
             label="Full Name"
+            defaultValue={quote?.customer.name}
             inputRef={register({ required: { value: true, message: 'Name is required' } })}
             inputProps={{ readOnly: !editable }}
             error={!!errors.name}
@@ -69,6 +66,7 @@ export const CustomerSection: React.FC = () => {
             className={styles.phone}
             name="phone"
             label="Phone"
+            defaultValue={quote?.customer.phone}
             inputRef={register}
             inputProps={{ readOnly: !editable }}
             InputLabelProps={{ shrink: true }}
@@ -77,6 +75,7 @@ export const CustomerSection: React.FC = () => {
             className={styles.address}
             name="address"
             label="Home Address"
+            defaultValue={quote?.customer.address}
             inputRef={register({ required: { value: true, message: 'Address is required' } })}
             inputProps={{ readOnly: !editable }}
             InputLabelProps={{ shrink: true }}
@@ -85,6 +84,7 @@ export const CustomerSection: React.FC = () => {
             className={styles.email}
             name="email"
             label="Email"
+            defaultValue={quote?.customer.email}
             inputRef={register({
               pattern: {
                 value: /^(([^<>()[]\\.,;:\s@"]+(\.[^<>()[]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/,

--- a/ui/src/views/routes/quotes/CustomerSection.tsx
+++ b/ui/src/views/routes/quotes/CustomerSection.tsx
@@ -1,0 +1,61 @@
+import { TextField } from '@material-ui/core';
+import { CustomerDto } from 'api/api-models';
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import styles from './CustomerSection.module.scss';
+import { QuoteSection } from './QuoteSection';
+
+export const CustomerSection: React.FC = () => {
+  const readOnly = false;
+
+  // TODO
+  const sectionTitle = 'Customer';
+  const sectionSummary = null;
+
+  const formMethods = useForm<CustomerDto>();
+  const { register, handleSubmit, reset, errors } = formMethods;
+  const onSubmit = (data: CustomerDto) => {
+    console.log({ data });
+  };
+
+  return (
+    <QuoteSection<CustomerDto>
+      sectionTitle="Customer"
+      sectionSummary="cutomer summary"
+      formMethods={formMethods}
+      onSubmit={onSubmit}>
+      <div className={styles.fields}>
+        <TextField
+          className={styles.name}
+          name="name"
+          label="Full Name"
+          inputRef={register({ required: { value: true, message: 'Name is required' } })}
+          inputProps={{ readOnly }}
+          error={!!errors.name}
+          helperText={errors?.name?.message}
+        />
+        <TextField
+          className={styles.phone}
+          name="phone"
+          label="Phone"
+          inputRef={register}
+          inputProps={{ readOnly }}
+        />
+        <TextField
+          className={styles.address}
+          name="address"
+          label="Home Address"
+          inputRef={register}
+          inputProps={{ readOnly }}
+        />
+        <TextField
+          className={styles.email}
+          name="email"
+          label="Email"
+          inputRef={register}
+          inputProps={{ readOnly }}
+        />
+      </div>
+    </QuoteSection>
+  );
+};

--- a/ui/src/views/routes/quotes/CustomerSection.tsx
+++ b/ui/src/views/routes/quotes/CustomerSection.tsx
@@ -1,12 +1,15 @@
 import { TextField } from '@material-ui/core';
 import { CustomerDto } from 'api/api-models';
-import React from 'react';
+import React, { useContext } from 'react';
 import { useForm } from 'react-hook-form';
 import styles from './CustomerSection.module.scss';
+import { QuoteContext } from './Quote';
 import { QuoteSection } from './QuoteSection';
 
 export const CustomerSection: React.FC = () => {
   const readOnly = false;
+
+  const quote = useContext(QuoteContext);
 
   // TODO
   const sectionTitle = 'Customer';
@@ -52,8 +55,16 @@ export const CustomerSection: React.FC = () => {
           className={styles.email}
           name="email"
           label="Email"
-          inputRef={register}
+          inputRef={register({
+            pattern: {
+              value: /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/,
+              message: 'Please provide a valid email address',
+            },
+            required: { value: true, message: 'Email is required' },
+          })}
           inputProps={{ readOnly }}
+          error={!!errors.email}
+          helperText={errors?.email?.message}
         />
       </div>
     </QuoteSection>

--- a/ui/src/views/routes/quotes/CustomerSection.tsx
+++ b/ui/src/views/routes/quotes/CustomerSection.tsx
@@ -1,15 +1,18 @@
 import { TextField } from '@material-ui/core';
 import { CustomerDto } from 'api/api-models';
+import * as QuotesApi from 'api/quotes.api';
 import React, { useContext } from 'react';
 import { useForm } from 'react-hook-form';
+import { useHistory } from 'react-router-dom';
 import styles from './CustomerSection.module.scss';
 import { QuoteContext } from './Quote';
 import { QuoteSection } from './QuoteSection';
 
 export const CustomerSection: React.FC = () => {
-  const readOnly = false;
-
+  const history = useHistory();
   const quote = useContext(QuoteContext);
+  const formMethods = useForm<CustomerDto>();
+  const { register, errors, setValue } = formMethods;
 
   React.useEffect(() => {
     // dont know why setting defaultValue on TextField didn't work
@@ -20,72 +23,82 @@ export const CustomerSection: React.FC = () => {
     setValue('phone', quote?.customer.phone);
     setValue('email', quote?.customer.email);
     setValue('address', quote?.customer.address);
-  }, [quote]);
+  }, [quote, setValue]);
 
-  // TODO
-  const sectionTitle = 'Customer';
-  const sectionSummary = null;
-
-  const formMethods = useForm<CustomerDto>();
-
-  const { register, handleSubmit, reset, errors, setValue } = formMethods;
-  const onSubmit = (data: CustomerDto) => {
-    console.log({ data });
+  const onSubmit = async (data: CustomerDto) => {
+    if (quote) {
+      await QuotesApi.updateQuoteCustomer({
+        quoteId: quote.id,
+        customerName: data.name,
+        customerAddress: data.address,
+        customerEmail: data.email,
+        customerPhone: data.phone,
+      });
+    } else {
+      const newQuoteId = await QuotesApi.createQuote({
+        customerName: data.name,
+        customerAddress: data.address,
+        customerEmail: data.email,
+        customerPhone: data.phone,
+      });
+      if (newQuoteId) {
+        history.replace(`/quotes/${newQuoteId}`);
+      }
+    }
   };
 
-  console.log({ quote });
   return (
     <QuoteSection<CustomerDto>
-      sectionTitle="Customer"
-      sectionSummary="cutomer summary"
+      sectionTitle={quote ? quote.customer.name : ''}
+      sectionSummary=""
       formMethods={formMethods}
       onSubmit={onSubmit}>
-      <div className={styles.fields}>
-        <TextField
-          className={styles.name}
-          name="name"
-          label="Full Name"
-          defaultValue=""
-          inputRef={register({ required: { value: true, message: 'Name is required' } })}
-          inputProps={{ readOnly }}
-          error={!!errors.name}
-          helperText={errors?.name?.message}
-          InputLabelProps={{ shrink: true }}
-        />
-        <TextField
-          className={styles.phone}
-          name="phone"
-          label="Phone"
-          defaultValue=""
-          inputRef={register}
-          inputProps={{ readOnly }}
-          InputLabelProps={{ shrink: true }}
-        />
-        <TextField
-          className={styles.address}
-          name="address"
-          label="Home Address"
-          inputRef={register}
-          inputProps={{ readOnly }}
-          InputLabelProps={{ shrink: true }}
-        />
-        <TextField
-          className={styles.email}
-          name="email"
-          label="Email"
-          inputRef={register({
-            pattern: {
-              value: /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/,
-              message: 'Please provide a valid email address',
-            },
-            required: { value: true, message: 'Email is required' },
-          })}
-          inputProps={{ readOnly }}
-          error={!!errors.email}
-          helperText={errors?.email?.message}
-          InputLabelProps={{ shrink: true }}
-        />
-      </div>
+      {({ editable }) => (
+        <div className={styles.fields}>
+          <TextField
+            className={styles.name}
+            name="name"
+            label="Full Name"
+            inputRef={register({ required: { value: true, message: 'Name is required' } })}
+            inputProps={{ readOnly: !editable }}
+            error={!!errors.name}
+            helperText={errors?.name?.message}
+            InputLabelProps={{ shrink: true }}
+          />
+          <TextField
+            className={styles.phone}
+            name="phone"
+            label="Phone"
+            inputRef={register}
+            inputProps={{ readOnly: !editable }}
+            InputLabelProps={{ shrink: true }}
+          />
+          <TextField
+            className={styles.address}
+            name="address"
+            label="Home Address"
+            inputRef={register({ required: { value: true, message: 'Address is required' } })}
+            inputProps={{ readOnly: !editable }}
+            InputLabelProps={{ shrink: true }}
+          />
+          <TextField
+            className={styles.email}
+            name="email"
+            label="Email"
+            inputRef={register({
+              pattern: {
+                value: /^(([^<>()[]\\.,;:\s@"]+(\.[^<>()[]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/,
+                message: 'Please provide a valid email address',
+              },
+              required: { value: true, message: 'Email is required' },
+            })}
+            inputProps={{ readOnly: !editable }}
+            error={!!errors.email}
+            helperText={errors?.email?.message}
+            InputLabelProps={{ shrink: true }}
+          />
+        </div>
+      )}
     </QuoteSection>
   );
 };

--- a/ui/src/views/routes/quotes/CustomerSection.tsx
+++ b/ui/src/views/routes/quotes/CustomerSection.tsx
@@ -53,7 +53,7 @@ export const CustomerSection: React.FC = () => {
       sectionSummary=""
       formMethods={formMethods}
       onSubmit={onSubmit}>
-      {({ editable }) => (
+      {editable => (
         <div className={styles.fields}>
           <TextField
             className={styles.name}

--- a/ui/src/views/routes/quotes/CustomerSection.tsx
+++ b/ui/src/views/routes/quotes/CustomerSection.tsx
@@ -11,8 +11,10 @@ import { QuoteSection } from './QuoteSection';
 export const CustomerSection: React.FC = () => {
   const history = useHistory();
   const { quote } = useContext(QuoteContext);
-  const formMethods = useForm<CustomerDto>();
-  const { register, errors } = formMethods;
+
+  // trigger validation when input focus changes
+  const formMethods = useForm<CustomerDto>({ mode: 'onBlur' });
+  const { register, errors, formState } = formMethods;
 
   const onSubmit = async (data: CustomerDto) => {
     if (quote) {
@@ -40,11 +42,12 @@ export const CustomerSection: React.FC = () => {
     Caveat: https://github.com/mui-org/material-ui/issues/11150
     defaultValue in TextField won't update when the component reloads
     use a LoadingPane to prevent the component from rendering until the data is fetched
- */
+  */
   return (
     <QuoteSection<CustomerDto>
-      sectionTitle={quote ? quote.customer.name : ''}
-      sectionSummary=""
+      sectionTitle="Customer"
+      sectionSummary={quote ? quote.customer.name : ''}
+      isEmpty={!quote?.customer}
       expandedDefault={!quote}
       editableDefault={!quote}
       formMethods={formMethods}
@@ -55,12 +58,12 @@ export const CustomerSection: React.FC = () => {
             className={styles.name}
             name="name"
             label="Full Name"
+            required
             defaultValue={quote?.customer.name}
-            inputRef={register({ required: { value: true, message: 'Name is required' } })}
             inputProps={{ readOnly: !editable }}
-            error={!!errors.name}
+            inputRef={register({ required: { value: true, message: 'Name is required' } })}
+            error={!!errors.name && (formState.isSubmitted || formState.touched.name)}
             helperText={errors?.name?.message}
-            InputLabelProps={{ shrink: true }}
           />
           <TextField
             className={styles.phone}
@@ -69,33 +72,34 @@ export const CustomerSection: React.FC = () => {
             defaultValue={quote?.customer.phone}
             inputRef={register}
             inputProps={{ readOnly: !editable }}
-            InputLabelProps={{ shrink: true }}
           />
           <TextField
             className={styles.address}
             name="address"
             label="Home Address"
+            required
             defaultValue={quote?.customer.address}
-            inputRef={register({ required: { value: true, message: 'Address is required' } })}
             inputProps={{ readOnly: !editable }}
-            InputLabelProps={{ shrink: true }}
+            inputRef={register({ required: { value: true, message: 'Address is required' } })}
+            error={!!errors.address && (formState.isSubmitted || formState.touched.address)}
+            helperText={errors?.address?.message}
           />
           <TextField
             className={styles.email}
             name="email"
             label="Email"
+            required
             defaultValue={quote?.customer.email}
+            inputProps={{ readOnly: !editable }}
             inputRef={register({
               pattern: {
-                value: /^(([^<>()[]\\.,;:\s@"]+(\.[^<>()[]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/,
+                value: /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/,
                 message: 'Please provide a valid email address',
               },
               required: { value: true, message: 'Email is required' },
             })}
-            inputProps={{ readOnly: !editable }}
-            error={!!errors.email}
+            error={!!errors.email && (formState.isSubmitted || formState.touched.email)}
             helperText={errors?.email?.message}
-            InputLabelProps={{ shrink: true }}
           />
         </div>
       )}

--- a/ui/src/views/routes/quotes/CustomerSection.tsx
+++ b/ui/src/views/routes/quotes/CustomerSection.tsx
@@ -11,16 +11,29 @@ export const CustomerSection: React.FC = () => {
 
   const quote = useContext(QuoteContext);
 
+  React.useEffect(() => {
+    // dont know why setting defaultValue on TextField didn't work
+    // e.g defaultValue={quote?.customer.name}
+    // refer to https://react-hook-form.com/get-started#Integrateglobalstate
+    // set the value explicitly here as a second option
+    setValue('name', quote?.customer.name);
+    setValue('phone', quote?.customer.phone);
+    setValue('email', quote?.customer.email);
+    setValue('address', quote?.customer.address);
+  }, [quote]);
+
   // TODO
   const sectionTitle = 'Customer';
   const sectionSummary = null;
 
   const formMethods = useForm<CustomerDto>();
-  const { register, handleSubmit, reset, errors } = formMethods;
+
+  const { register, handleSubmit, reset, errors, setValue } = formMethods;
   const onSubmit = (data: CustomerDto) => {
     console.log({ data });
   };
 
+  console.log({ quote });
   return (
     <QuoteSection<CustomerDto>
       sectionTitle="Customer"
@@ -32,17 +45,21 @@ export const CustomerSection: React.FC = () => {
           className={styles.name}
           name="name"
           label="Full Name"
+          defaultValue=""
           inputRef={register({ required: { value: true, message: 'Name is required' } })}
           inputProps={{ readOnly }}
           error={!!errors.name}
           helperText={errors?.name?.message}
+          InputLabelProps={{ shrink: true }}
         />
         <TextField
           className={styles.phone}
           name="phone"
           label="Phone"
+          defaultValue=""
           inputRef={register}
           inputProps={{ readOnly }}
+          InputLabelProps={{ shrink: true }}
         />
         <TextField
           className={styles.address}
@@ -50,6 +67,7 @@ export const CustomerSection: React.FC = () => {
           label="Home Address"
           inputRef={register}
           inputProps={{ readOnly }}
+          InputLabelProps={{ shrink: true }}
         />
         <TextField
           className={styles.email}
@@ -65,6 +83,7 @@ export const CustomerSection: React.FC = () => {
           inputProps={{ readOnly }}
           error={!!errors.email}
           helperText={errors?.email?.message}
+          InputLabelProps={{ shrink: true }}
         />
       </div>
     </QuoteSection>

--- a/ui/src/views/routes/quotes/Quote.module.scss
+++ b/ui/src/views/routes/quotes/Quote.module.scss
@@ -1,0 +1,4 @@
+.content {
+  display: grid;
+  grid-row-gap: 16px;
+}

--- a/ui/src/views/routes/quotes/Quote.tsx
+++ b/ui/src/views/routes/quotes/Quote.tsx
@@ -8,9 +8,13 @@ import { CustomerSection } from './CustomerSection';
 import styles from './Quote.module.scss';
 import { QuoteStatus } from './QuoteStatus';
 
+export const QuoteContext = React.createContext<QuoteDto | null>(null);
+
 export const Quote: React.FC = () => {
   const { quoteId } = useParams();
   const [quote, setQuote] = useState<QuoteDto | null>(null);
+  const QuoteContext = React.createContext<QuoteDto | null>(null);
+
   const loadQuote = async () => {
     setQuote(await QuotesApi.loadQuote(quoteId || ''));
   };
@@ -31,16 +35,18 @@ export const Quote: React.FC = () => {
   ) : null;
 
   return (
-    <PageLayout
-      title={title}
-      subtitle={quoteStatus}
-      parent={['All Quotes', '/quotes']}
-      audit={audit}>
-      <LoadingPane isLoading={false}>
-        <div className={styles.content}>
-          <CustomerSection></CustomerSection>
-        </div>
-      </LoadingPane>
-    </PageLayout>
+    <QuoteContext.Provider value={quote}>
+      <PageLayout
+        title={title}
+        subtitle={quoteStatus}
+        parent={['All Quotes', '/quotes']}
+        audit={audit}>
+        <LoadingPane isLoading={false}>
+          <div className={styles.content}>
+            <CustomerSection></CustomerSection>
+          </div>
+        </LoadingPane>
+      </PageLayout>
+    </QuoteContext.Provider>
   );
 };

--- a/ui/src/views/routes/quotes/Quote.tsx
+++ b/ui/src/views/routes/quotes/Quote.tsx
@@ -4,6 +4,7 @@ import React, { useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { LoadingPane } from 'views/components/application/LoadingPane';
 import { PageLayout } from 'views/components/application/PageLayout';
+import { CustomerSection } from './CustomerSection';
 import styles from './Quote.module.scss';
 import { QuoteStatus } from './QuoteStatus';
 
@@ -36,7 +37,9 @@ export const Quote: React.FC = () => {
       parent={['All Quotes', '/quotes']}
       audit={audit}>
       <LoadingPane isLoading={false}>
-        <div className={styles.content}></div>
+        <div className={styles.content}>
+          <CustomerSection></CustomerSection>
+        </div>
       </LoadingPane>
     </PageLayout>
   );

--- a/ui/src/views/routes/quotes/Quote.tsx
+++ b/ui/src/views/routes/quotes/Quote.tsx
@@ -8,18 +8,25 @@ import { CustomerSection } from './CustomerSection';
 import styles from './Quote.module.scss';
 import { QuoteStatus } from './QuoteStatus';
 
-export const QuoteContext = React.createContext<QuoteDto | null>(null);
+export interface IQuoteContext {
+  quote?: QuoteDto;
+  isLoading: boolean;
+}
+
+export const QuoteContext = React.createContext<IQuoteContext>({ isLoading: true });
 
 export const Quote: React.FC = () => {
   const { quoteId } = useParams();
-  const [quote, setQuote] = useState<QuoteDto | null>(null);
+  const [isLoading, setLoading] = useState<boolean>(true);
+  const [quote, setQuote] = useState<QuoteDto | undefined>(undefined);
 
   const loadQuote = async (id: string) => {
     setQuote(await QuotesApi.loadQuote(id || ''));
+    setLoading(false);
   };
 
   React.useEffect(() => {
-    quoteId && loadQuote(quoteId);
+    !!quoteId ? loadQuote(quoteId) : setLoading(false);
   }, [quoteId]);
 
   const title = quoteId
@@ -38,13 +45,13 @@ export const Quote: React.FC = () => {
   ) : null;
 
   return (
-    <QuoteContext.Provider value={quote}>
+    <QuoteContext.Provider value={{ quote, isLoading }}>
       <PageLayout
         title={title}
         subtitle={quoteStatus}
         parent={['All Quotes', '/quotes']}
         audit={audit}>
-        <LoadingPane isLoading={false}>
+        <LoadingPane isLoading={isLoading}>
           <div className={styles.content}>
             <CustomerSection></CustomerSection>
           </div>

--- a/ui/src/views/routes/quotes/Quote.tsx
+++ b/ui/src/views/routes/quotes/Quote.tsx
@@ -13,11 +13,14 @@ export const QuoteContext = React.createContext<QuoteDto | null>(null);
 export const Quote: React.FC = () => {
   const { quoteId } = useParams();
   const [quote, setQuote] = useState<QuoteDto | null>(null);
-  const QuoteContext = React.createContext<QuoteDto | null>(null);
 
-  const loadQuote = async () => {
-    setQuote(await QuotesApi.loadQuote(quoteId || ''));
+  const loadQuote = async (id: string) => {
+    setQuote(await QuotesApi.loadQuote(id || ''));
   };
+
+  React.useEffect(() => {
+    quoteId && loadQuote(quoteId);
+  }, [quoteId]);
 
   const title = quoteId
     ? quote?.statusCode === QuoteStatusCode.Draft

--- a/ui/src/views/routes/quotes/Quote.tsx
+++ b/ui/src/views/routes/quotes/Quote.tsx
@@ -1,0 +1,43 @@
+import { QuoteDto, QuoteStatusCode } from 'api/api-models';
+import * as QuotesApi from 'api/quotes.api';
+import React, { useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { LoadingPane } from 'views/components/application/LoadingPane';
+import { PageLayout } from 'views/components/application/PageLayout';
+import styles from './Quote.module.scss';
+import { QuoteStatus } from './QuoteStatus';
+
+export const Quote: React.FC = () => {
+  const { quoteId } = useParams();
+  const [quote, setQuote] = useState<QuoteDto | null>(null);
+  const loadQuote = async () => {
+    setQuote(await QuotesApi.loadQuote(quoteId || ''));
+  };
+
+  const title = quoteId
+    ? quote?.statusCode === QuoteStatusCode.Draft
+      ? 'Draft Quote'
+      : `Quote ${quote?.quoteNumber}`
+    : 'New Quote';
+
+  const quoteStatus = quoteId && quote && <QuoteStatus statusCode={quote.statusCode}></QuoteStatus>;
+
+  const audit = quote ? (
+    <span>
+      <strong>Last Updated: </strong>
+      <span>{quote.lastModifiedAt.toLocaleString()}</span>
+    </span>
+  ) : null;
+
+  return (
+    <PageLayout
+      title={title}
+      subtitle={quoteStatus}
+      parent={['All Quotes', '/quotes']}
+      audit={audit}>
+      <LoadingPane isLoading={false}>
+        <div className={styles.content}></div>
+      </LoadingPane>
+    </PageLayout>
+  );
+};

--- a/ui/src/views/routes/quotes/QuoteSection.module.scss
+++ b/ui/src/views/routes/quotes/QuoteSection.module.scss
@@ -1,0 +1,25 @@
+.title {
+  font-weight: bold;
+  font-size: 110%;
+}
+
+.expand {
+  color: red;
+}
+
+.spacer {
+  flex-grow: 1;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  flex-direction: row-reverse;
+  justify-content: flex-start;
+  padding: 8px 24px 16px 24px;
+
+  > :not(.spacer) {
+    min-width: 7em;
+    margin: 4px 8px;
+  }
+}

--- a/ui/src/views/routes/quotes/QuoteSection.tsx
+++ b/ui/src/views/routes/quotes/QuoteSection.tsx
@@ -1,0 +1,91 @@
+import {
+  Button,
+  ExpansionPanel,
+  ExpansionPanelActions,
+  ExpansionPanelDetails,
+  ExpansionPanelSummary,
+  Typography,
+} from '@material-ui/core';
+import AddIcon from '@material-ui/icons/Add';
+import CloseIcon from '@material-ui/icons/Close';
+import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import React from 'react';
+import { FormContextValues } from 'react-hook-form';
+import styles from './QuoteSection.module.scss';
+
+export interface IQuoteSectionProps<T> {
+  sectionTitle: string;
+  sectionSummary?: string;
+  onSubmit: (data: T) => void | Promise<void>;
+  formMethods: FormContextValues<T>;
+  children: React.ReactNode;
+}
+
+export function QuoteSection<T>({
+  sectionTitle,
+  sectionSummary,
+  onSubmit,
+  formMethods,
+  children,
+}: IQuoteSectionProps<T>) {
+  const { register, handleSubmit, reset, errors } = formMethods;
+  const formSubmit = (data: T) => {
+    console.log({ data });
+  };
+  const sectionData = true;
+
+  const [expanded, setExpanded] = React.useState<boolean>(true);
+  const [editable, setEditable] = React.useState<boolean>(true);
+  const IconComponent = sectionData ? ExpandMoreIcon : expanded ? CloseIcon : AddIcon;
+  const icon = <IconComponent className={styles.expand} />;
+
+  return (
+    <form onSubmit={handleSubmit(formSubmit)} noValidate autoComplete="off">
+      <ExpansionPanel
+        expanded={expanded}
+        onChange={(_, e) => {
+          setExpanded(e);
+          if (editable) {
+            //resetForm();
+            setEditable(false);
+          }
+        }}>
+        <ExpansionPanelSummary expandIcon={icon}>
+          <Typography>
+            <span className={styles.title}>{sectionTitle}</span>
+          </Typography>
+          {sectionSummary && (
+            <>
+              <span className={styles.spacer} aria-hidden="true" />
+              <Typography>
+                <span className={styles.summary}>{sectionSummary}</span>
+              </Typography>
+            </>
+          )}
+        </ExpansionPanelSummary>
+        <ExpansionPanelDetails>{children}</ExpansionPanelDetails>
+        {editable && (
+          <ExpansionPanelActions className={styles.actions} {...{ disableSpacing: true }}>
+            {editable ? (
+              <>
+                <Button type="submit" color="primary" variant="contained">
+                  Save
+                </Button>
+                <div className={styles.spacer} aria-hidden="true" />
+                {!!sectionData && <Button variant="contained">Clear</Button>}
+                <Button variant="contained">Cancel</Button>
+              </>
+            ) : (
+              <Button
+                onClick={() => {
+                  setEditable(true);
+                }}>
+                Edit
+              </Button>
+            )}
+          </ExpansionPanelActions>
+        )}
+      </ExpansionPanel>
+    </form>
+  );
+}

--- a/ui/src/views/routes/quotes/QuoteSection.tsx
+++ b/ui/src/views/routes/quotes/QuoteSection.tsx
@@ -18,7 +18,7 @@ export interface IQuoteSectionProps<T> {
   sectionSummary?: string;
   onSubmit: (data: T) => void | Promise<void>;
   formMethods: FormContextValues<T>;
-  children: (args: { editable: boolean }) => React.ReactNode;
+  children: (editable: boolean) => React.ReactNode;
 }
 
 export function QuoteSection<T>({
@@ -64,7 +64,7 @@ export function QuoteSection<T>({
             </>
           )}
         </ExpansionPanelSummary>
-        <ExpansionPanelDetails>{children({ editable })}</ExpansionPanelDetails>
+        <ExpansionPanelDetails>{children(editable)}</ExpansionPanelDetails>
         {editable && (
           <ExpansionPanelActions className={styles.actions} {...{ disableSpacing: true }}>
             {editable ? (

--- a/ui/src/views/routes/quotes/QuoteSection.tsx
+++ b/ui/src/views/routes/quotes/QuoteSection.tsx
@@ -18,7 +18,7 @@ export interface IQuoteSectionProps<T> {
   sectionSummary?: string;
   onSubmit: (data: T) => void | Promise<void>;
   formMethods: FormContextValues<T>;
-  children: React.ReactNode;
+  children: (args: { editable: boolean }) => React.ReactNode;
 }
 
 export function QuoteSection<T>({
@@ -29,8 +29,9 @@ export function QuoteSection<T>({
   children,
 }: IQuoteSectionProps<T>) {
   const { register, handleSubmit, reset, errors } = formMethods;
-  const formSubmit = (data: T) => {
-    console.log({ data });
+  const formSubmit = async (data: T) => {
+    await onSubmit(data);
+    // TODO: toggle button status
   };
   const sectionData = true;
 
@@ -63,7 +64,7 @@ export function QuoteSection<T>({
             </>
           )}
         </ExpansionPanelSummary>
-        <ExpansionPanelDetails>{children}</ExpansionPanelDetails>
+        <ExpansionPanelDetails>{children({ editable })}</ExpansionPanelDetails>
         {editable && (
           <ExpansionPanelActions className={styles.actions} {...{ disableSpacing: true }}>
             {editable ? (

--- a/ui/src/views/routes/quotes/QuoteSection.tsx
+++ b/ui/src/views/routes/quotes/QuoteSection.tsx
@@ -16,6 +16,8 @@ import styles from './QuoteSection.module.scss';
 export interface IQuoteSectionProps<T> {
   sectionTitle: string;
   sectionSummary?: string;
+  expandedDefault: boolean;
+  editableDefault: boolean;
   onSubmit: (data: T) => void | Promise<void>;
   formMethods: FormContextValues<T>;
   children: (editable: boolean) => React.ReactNode;
@@ -24,19 +26,21 @@ export interface IQuoteSectionProps<T> {
 export function QuoteSection<T>({
   sectionTitle,
   sectionSummary,
+  expandedDefault,
+  editableDefault,
   onSubmit,
   formMethods,
   children,
 }: IQuoteSectionProps<T>) {
-  const { register, handleSubmit, reset, errors } = formMethods;
+  const { handleSubmit, reset } = formMethods;
   const formSubmit = async (data: T) => {
     await onSubmit(data);
     // TODO: toggle button status
   };
   const sectionData = true;
 
-  const [expanded, setExpanded] = React.useState<boolean>(true);
-  const [editable, setEditable] = React.useState<boolean>(true);
+  const [expanded, setExpanded] = React.useState<boolean>(expandedDefault);
+  const [editable, setEditable] = React.useState<boolean>(editableDefault);
   const IconComponent = sectionData ? ExpandMoreIcon : expanded ? CloseIcon : AddIcon;
   const icon = <IconComponent className={styles.expand} />;
 
@@ -74,7 +78,14 @@ export function QuoteSection<T>({
                 </Button>
                 <div className={styles.spacer} aria-hidden="true" />
                 {!!sectionData && <Button variant="contained">Clear</Button>}
-                <Button variant="contained">Cancel</Button>
+                <Button
+                  variant="contained"
+                  onClick={() => {
+                    reset();
+                    setEditable(false);
+                  }}>
+                  Cancel
+                </Button>
               </>
             ) : (
               <Button

--- a/ui/src/views/routes/quotes/QuoteSection.tsx
+++ b/ui/src/views/routes/quotes/QuoteSection.tsx
@@ -16,6 +16,7 @@ import styles from './QuoteSection.module.scss';
 export interface IQuoteSectionProps<T> {
   sectionTitle: string;
   sectionSummary?: string;
+  isEmpty: boolean;
   expandedDefault: boolean;
   editableDefault: boolean;
   onSubmit: (data: T) => void | Promise<void>;
@@ -26,6 +27,7 @@ export interface IQuoteSectionProps<T> {
 export function QuoteSection<T>({
   sectionTitle,
   sectionSummary,
+  isEmpty,
   expandedDefault,
   editableDefault,
   onSubmit,
@@ -35,13 +37,13 @@ export function QuoteSection<T>({
   const { handleSubmit, reset } = formMethods;
   const formSubmit = async (data: T) => {
     await onSubmit(data);
-    // TODO: toggle button status
+    setEditable(false);
   };
-  const sectionData = true;
 
   const [expanded, setExpanded] = React.useState<boolean>(expandedDefault);
   const [editable, setEditable] = React.useState<boolean>(editableDefault);
-  const IconComponent = sectionData ? ExpandMoreIcon : expanded ? CloseIcon : AddIcon;
+
+  const IconComponent = !isEmpty ? ExpandMoreIcon : expanded ? CloseIcon : AddIcon;
   const icon = <IconComponent className={styles.expand} />;
 
   return (
@@ -51,7 +53,7 @@ export function QuoteSection<T>({
         onChange={(_, e) => {
           setExpanded(e);
           if (editable) {
-            //resetForm();
+            reset();
             setEditable(false);
           }
         }}>
@@ -69,34 +71,38 @@ export function QuoteSection<T>({
           )}
         </ExpansionPanelSummary>
         <ExpansionPanelDetails>{children(editable)}</ExpansionPanelDetails>
-        {editable && (
-          <ExpansionPanelActions className={styles.actions} {...{ disableSpacing: true }}>
-            {editable ? (
-              <>
-                <Button type="submit" color="primary" variant="contained">
-                  Save
-                </Button>
-                <div className={styles.spacer} aria-hidden="true" />
-                {!!sectionData && <Button variant="contained">Clear</Button>}
-                <Button
-                  variant="contained"
-                  onClick={() => {
-                    reset();
-                    setEditable(false);
-                  }}>
-                  Cancel
-                </Button>
-              </>
-            ) : (
-              <Button
-                onClick={() => {
-                  setEditable(true);
-                }}>
-                Edit
+        <ExpansionPanelActions className={styles.actions} {...{ disableSpacing: true }}>
+          {editable ? (
+            <>
+              <Button type="submit" color="primary" variant="contained">
+                Save
               </Button>
-            )}
-          </ExpansionPanelActions>
-        )}
+              <div className={styles.spacer} aria-hidden="true" />
+              <Button
+                variant="contained"
+                color="secondary"
+                type="button"
+                onClick={(e) => {
+                  reset();
+                  setEditable(false);
+                  e.preventDefault();
+                }}>
+                Cancel
+              </Button>
+            </>
+          ) : (
+            <Button
+              variant="contained"
+              color="secondary"
+              type="button"
+              onClick={(e) => {
+                setEditable(true);
+                e.preventDefault();
+              }}>
+              Edit
+            </Button>
+          )}
+        </ExpansionPanelActions>
       </ExpansionPanel>
     </form>
   );

--- a/ui/src/views/routes/quotes/QuotesList.tsx
+++ b/ui/src/views/routes/quotes/QuotesList.tsx
@@ -2,7 +2,7 @@ import { Button, Table, TableBody, TableCell, TableHead, TableRow } from '@mater
 import { QuoteSummaryDto } from 'api/api-models';
 import * as QuotesApi from 'api/quotes.api';
 import React, { useEffect, useState } from 'react';
-import { useHistory } from 'react-router-dom';
+import { Link, useHistory } from 'react-router-dom';
 import { LoadingPane } from 'views/components/application/LoadingPane';
 import { PageLayout } from 'views/components/application/PageLayout';
 import styles from './QuotesList.module.scss';
@@ -19,8 +19,6 @@ export const QuotesList: React.FC = () => {
     loadQuotes();
   }, []);
 
-  const createQuote = () => {};
-
   return (
     <PageLayout title="All Quotes" parent="none">
       <div className={styles.actions}>
@@ -28,7 +26,8 @@ export const QuotesList: React.FC = () => {
           className={styles.newquote}
           color="primary"
           variant="contained"
-          onClick={createQuote}>
+          component={Link}
+          to="/quotes/new">
           Create Quote
         </Button>
       </div>


### PR DESCRIPTION
Allow user to:
- Create a new quote by providing customer details (not E2E yet)
- Update customer info in an existing quote

Still missing:
- mock server handles `POST /quotes/` and return new quote id and quote number
- mock server save the new quote and return that in request `GET /quotes` and `GET /quotes/:id` (is that built-in?)

